### PR TITLE
Add hotkeys for warping to benches

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Bench Hotkeys
 - **DM**: **D**irt**M**outh
 - **FC**: **F**orgotten **C**rossroads Stag
 - **FS**: **F**orgotten Crossroads Hot **S**prings
-- **AM**: **A**ncestral **M**ound
+- **SM**: Ancestral (**S**haman) **M**ound
 - **SA**: **SA**lubra
 - **BE**: **B**lack **E**gg
 - **GW**: **G**reenpath **W**aterfall

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Options
 - Use Room Names: bench menu uses room names from the game code instead of descriptive names
 - Enable Deploy: adds a menu to place a custom bench point
 - Always Toggle All: all bench menus are displayed by default
+- Enable Hotkeys: lets you warp to benches by typing a short key sequence rather than clicking the menu
 
 Deploy
 - Deploy button: places a bench at the current location
@@ -21,6 +22,60 @@ Deploy
 	- No Dark Rooms or Dream Rooms: prevents use of deploy in Dream World rooms, and if the player does not have lantern, prevents use of deploy in rooms which are dark
 	- Reduce Preloads: when the game starts up, only the selected style is preloaded. To use other styles, the player must restart the game.
 	- No preloads: no bench styles are preloaded. The deploy button instead will create a respawn marker. To deploy benches, the player must change the setting and restart.
+
+Bench Hotkeys
+- **KP**: **K**ing's **P**ass
+- **NM**: **N**ailmaster **M**ato
+- **DM**: **D**irt**M**outh
+- **FC**: **F**orgotten **C**rossroads Stag
+- **FS**: **F**orgotten Crossroads Hot **S**prings
+- **AM**: **A**ncestral **M**ound
+- **SA**: **SA**lubra
+- **BE**: **B**lack **E**gg
+- **GW**: **G**reenpath **W**aterfall
+- **SS**: **S**tone **S**anctuary
+- **GT**: **G**reenpath **T**oll
+- **GP**: **G**reen**P**ath Stag
+- **LU**: **L**ake of **U**nn
+- **NS**: **N**ailmaster **S**heo
+- **TA**: **T**eacher's **A**rchives
+- **QS**: **Q**ueen's **S**tation
+- **LE**: **L**eg **E**ater
+- **BR**: **BR**etta
+- **MV**: **M**antis **V**illage
+- **CQ**: **C**ity **Q**uirrel
+- **CT**: **C**ity **T**oll
+- **CS**: **C**ity **S**torerooms
+- **WS**: **W**atcher **S**pire
+- **KS**: **K**ing's **S**tation
+- **PH**: **P**leasure **H**ouse
+- **WW**: **W**ater**W**ays
+- **GA**: **G**odhome **A**trium
+- **GR**: **G**odhome **R**oof
+- **HG**: **H**all of **G**ods
+- **DS**: **D**eepnest Hot **S**prings
+- **FT**: **F**ailed **T**ramway
+- **BD**: **B**east's **D**en
+- **BT**: **B**asin **T**oll
+- **HS**: **H**idden **S**tation
+- **NO**: **N**ailmaster **O**ro
+- **EC**: **E**dge **C**amp
+- **CF**: **C**olosseum of **F**ools
+- **BB**: Hive (**b**ee-**b**ee)
+- **PD**: **P**eak **D**ark Room
+- **CG**: **C**rystal **G**uardian
+- **RG**: **R**esting **G**rounds Stag
+- **GM**: **G**rey **M**ourner
+- **QC**: **Q**ueen's Gardens **C**ornifer
+- **QT**: **Q**ueen's Gardens **T**oll
+- **QG**: **Q**ueen's Gardens **S**tag
+- **PE**: **P**alace **E**ntrance
+- **PA**: **P**alace **A**trium
+- **PB**: **P**alace **B**alcony
+- **UT**: **U**pper **T**ram
+- **LT**: **L**ower **T**ram
+- **LB**: **L**ast **B**ench (equivalent to just clicking Warp)
+- **SB**: **S**tart **B**ench (equivalent to Set Start)
 
 Credits
 Seanpr - developed the UI, as part of DebugMod

--- a/README.md
+++ b/README.md
@@ -77,6 +77,11 @@ Bench Hotkeys
 - **LB**: **L**ast **B**ench (equivalent to just clicking Warp)
 - **SB**: **S**tart **B**ench (equivalent to Set Start)
 
+Each hotkey can be remapped by modifying the "hotkeyOverrides" dictionary in the
+mod's global settings file (Benchwarp.GlobalSettings.json, in your saves folder). This dictionary
+should map the default bindings to their replacements. For example, `"hotkeyOverrides": {"BB": "HV"}` remaps the Hive bench to use the hotkey "HV".
+Custom hotkeys must be composed of exactly two uppercase letters.
+
 Credits
 Seanpr - developed the UI, as part of DebugMod
 Seanpr and 5FiftySix6 - developed the Warp method, as part of this mod

--- a/Source/Benchwarp.cs
+++ b/Source/Benchwarp.cs
@@ -71,7 +71,7 @@ namespace Benchwarp
 
         public override string GetVersion()
         {
-            return "2.3";
+            return "2.3H";
         }
 
         public override int LoadPriority()

--- a/Source/Benchwarp.cs
+++ b/Source/Benchwarp.cs
@@ -272,6 +272,52 @@ namespace Benchwarp
             orig(self);
         }
 
+        internal void ApplyUnlockAllFixes() {
+            if (!globalSettings.UnlockAllBenches) return;
+
+            PlayerData pd = PlayerData.instance;
+
+            FieldInfo[] fields = typeof(PlayerData).GetFields();
+
+            // Most of these are unnecessary, but some titlecards can lock you into a bench
+            foreach
+            (
+                FieldInfo fi in fields.Where
+                (
+                    x => x.Name.StartsWith("visited")
+                        || x.Name.StartsWith("tramOpened")
+                        || x.Name.StartsWith("openedTram")
+                        || x.Name.StartsWith("tramOpened")
+                )
+            )
+            {
+                pd.SetBoolInternal(fi.Name, true);
+            }
+
+            //This actually fixes the unlockable benches
+            SceneData sd = GameManager.instance.sceneData;
+
+            foreach ((string sceneName, string id) in new (string, string)[]
+            {
+                ("Hive_01", "Hive Bench"),
+                ("Ruins1_31", "Toll Machine Bench"),
+                ("Abyss_18", "Toll Machine Bench"),
+                ("Fungus3_50", "Toll Machine Bench")
+            })
+            {
+                sd.SaveMyState
+                (
+                    new PersistentBoolData
+                    {
+                        sceneName = sceneName,
+                        id = id,
+                        activated = true,
+                        semiPersistent = false
+                    }
+                );
+            }
+        }
+
         public void Unload()
         {
             ModHooks.Instance.SetPlayerBoolHook -= BenchWatcher;

--- a/Source/Benchwarp.cs
+++ b/Source/Benchwarp.cs
@@ -17,6 +17,8 @@ namespace Benchwarp
 
         internal static Benchwarp instance;
 
+        internal Dictionary<string, int> Hotkeys = new Dictionary<string, int>();
+
         internal GameObject UIObj;
         internal GlobalSettings globalSettings = new GlobalSettings();
         internal SaveSettings saveSettings = new SaveSettings();
@@ -63,6 +65,8 @@ namespace Benchwarp
 
             // Imagine if GetPlayerIntHook actually worked
             On.GameManager.OnNextLevelReady += FixRespawnType;
+
+            ApplyHotkeyOverrides();
         }
 
         public override string GetVersion()
@@ -133,6 +137,95 @@ namespace Benchwarp
                 ("White_Palace_01", "WhiteBench"),
                 ("Room_Final_Boss_Atrium", "RestBench")
                 };
+        }
+
+        private static Dictionary<string, int> DefaultHotkeys = new Dictionary<string, int>() {
+            {"KP", 0},
+            {"DM", 1},
+            {"NM", 2},
+
+            {"FS", 3},
+            {"FC", 4},
+            {"SA", 5},
+            {"AM", 6},
+            {"BE", 7},
+
+            {"GW", 8},
+            {"SS", 9},
+            {"GT", 10},
+            {"GP", 11},
+            {"LU", 12},
+            {"NS", 13},
+
+            {"TA", 14},
+
+            {"QS", 15},
+            {"LE", 16},
+            {"BR", 17},
+            {"MV", 18},
+
+            {"CQ", 19},
+            {"CT", 20},
+            {"CS", 21},
+            {"WS", 22},
+            {"KS", 23},
+            {"PH", 24},
+
+            {"WW", 25},
+            {"GA", 26},
+            {"GR", 27},
+            {"HG", 28},
+
+            {"DS", 29},
+            {"FT", 30},
+            {"BD", 31},
+
+            {"BT", 32},
+            {"HS", 33},
+
+            {"NO", 34},
+            {"EC", 35},
+            {"CF", 36},
+            {"BB", 37},
+
+            {"PD", 38},
+            {"CG", 39},
+
+            {"RG", 40},
+            {"GM", 41},
+
+            {"QC", 42},
+            {"QT", 43},
+            {"QG", 44},
+
+            {"PE", 45},
+            {"PA", 46},
+            {"PB", 47},
+
+            {"UT", 48},
+            {"LT", 49},
+
+            {"LB", -1},
+            {"SB", -2}
+        };
+
+        private void ApplyHotkeyOverrides()
+        {
+            foreach (var defaultBind in DefaultHotkeys)
+            {
+                if (!globalSettings.HotkeyOverrides.TryGetValue(defaultBind.Key, out var mappedHotkey))
+                {
+                    mappedHotkey = defaultBind.Key;
+                }
+                try
+                {
+                    Hotkeys.Add(mappedHotkey, defaultBind.Value);
+                }
+                catch (System.ArgumentException)
+                {
+                    LogError($"duplicate binding for hotkey '{mappedHotkey}'");
+                }
+            }
         }
 
         public void Warp()

--- a/Source/Benchwarp.cs
+++ b/Source/Benchwarp.cs
@@ -147,7 +147,7 @@ namespace Benchwarp
             {"FS", 3},
             {"FC", 4},
             {"SA", 5},
-            {"AM", 6},
+            {"SM", 6},
             {"BE", 7},
 
             {"GW", 8},

--- a/Source/Benchwarp.cs
+++ b/Source/Benchwarp.cs
@@ -135,6 +135,11 @@ namespace Benchwarp
                 };
         }
 
+        public void Warp()
+        {
+            GameManager.instance.StartCoroutine(Respawn());
+        }
+
         public IEnumerator Respawn()
         {
             GameManager.instance.SaveGame();

--- a/Source/Benchwarp.cs
+++ b/Source/Benchwarp.cs
@@ -71,7 +71,7 @@ namespace Benchwarp
 
         public override string GetVersion()
         {
-            return "2.3H";
+            return "2.3";
         }
 
         public override int LoadPriority()

--- a/Source/Benchwarp.csproj
+++ b/Source/Benchwarp.csproj
@@ -107,4 +107,7 @@
     <PreBuildEvent>
     </PreBuildEvent>
   </PropertyGroup>
+  <PropertyGroup>
+    <PostBuildEvent>copy "$(TargetPath)" "C:\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\Mods"</PostBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/Source/Benchwarp.csproj
+++ b/Source/Benchwarp.csproj
@@ -107,7 +107,4 @@
     <PreBuildEvent>
     </PreBuildEvent>
   </PropertyGroup>
-  <PropertyGroup>
-    <PostBuildEvent>copy "$(TargetPath)" "C:\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\Mods"</PostBuildEvent>
-  </PropertyGroup>
 </Project>

--- a/Source/GUIController.cs
+++ b/Source/GUIController.cs
@@ -128,11 +128,19 @@ namespace Benchwarp
                 last2Keystrokes = "";
                 Benchwarp.instance.ApplyUnlockAllFixes();
                 Bench.Benches[benchNum].SetBench();
-                GameManager.instance.StartCoroutine(Benchwarp.instance.Respawn());
+                Benchwarp.instance.Warp();
             }
-            else if (last2Keystrokes == "lb")
+            else switch (last2Keystrokes)
             {
-                GameManager.instance.StartCoroutine(Benchwarp.instance.Respawn());
+                case "lb":
+                    last2Keystrokes = "";
+                    Benchwarp.instance.Warp();
+                    break;
+                case "sb":
+                    last2Keystrokes = "";
+                    CustomStartLocation.SetStart();
+                    Benchwarp.instance.Warp();
+                    break;
             }
         }
 

--- a/Source/GUIController.cs
+++ b/Source/GUIController.cs
@@ -19,6 +19,8 @@ namespace Benchwarp
         
         public Dictionary<string, Texture2D> images = new Dictionary<string, Texture2D>();
 
+        private string last2Keystrokes = "";
+
         private GameObject canvas;
         private static GUIController _instance;
 
@@ -101,6 +103,23 @@ namespace Benchwarp
         public void Update()
         {
             TopMenu.Update();
+            foreach (var letter in BenchLetters)
+            {
+                if (Input.GetKeyDown(letter.Key))
+                {
+                    Benchwarp.instance.Log($"pressed {letter.Key} {letter.Value}");
+                    if (last2Keystrokes.Length == 2)
+                    {
+                        last2Keystrokes = last2Keystrokes.Remove(0, 1);
+                    }
+                    last2Keystrokes = last2Keystrokes + letter.Value;
+                }
+            }
+            if (BenchHotkeys.TryGetValue(last2Keystrokes, out int benchNum))
+            {
+                last2Keystrokes = "";
+                Benchwarp.instance.Log($"hit hotkey {last2Keystrokes} for bench {Bench.Benches[benchNum]}");
+            }
         }
 
         public static GUIController Instance
@@ -122,5 +141,95 @@ namespace Benchwarp
                 return _instance;
             }
         }
+
+        private static Dictionary<KeyCode, char> BenchLetters = new Dictionary<KeyCode, char>() {
+            {KeyCode.A, 'a'},
+            {KeyCode.B, 'b'},
+            {KeyCode.C, 'c'},
+            {KeyCode.D, 'd'},
+            {KeyCode.E, 'e'},
+            {KeyCode.F, 'f'},
+            {KeyCode.G, 'g'},
+            {KeyCode.H, 'h'},
+            {KeyCode.K, 'k'},
+            {KeyCode.L, 'l'},
+            {KeyCode.M, 'm'},
+            {KeyCode.N, 'n'},
+            {KeyCode.O, 'o'},
+            {KeyCode.P, 'p'},
+            {KeyCode.Q, 'q'},
+            {KeyCode.R, 'r'},
+            {KeyCode.S, 's'},
+            {KeyCode.T, 't'},
+            {KeyCode.U, 'u'},
+            {KeyCode.W, 'w'}
+        };
+
+        private static Dictionary<string, int> BenchHotkeys = new Dictionary<string, int>() {
+            {"kp", 0},
+            {"dm", 1},
+            {"nm", 2},
+
+            {"fs", 3},
+            {"fc", 4},
+            {"sa", 5},
+            {"am", 6},
+            {"be", 7},
+
+            {"gw", 8},
+            {"ss", 9},
+            {"gt", 10},
+            {"gp", 11},
+            {"lu", 12},
+            {"ns", 13},
+
+            {"ta", 14},
+
+            {"qs", 15},
+            {"le", 16},
+            {"br", 17},
+            {"mv", 18},
+
+            {"cq", 19},
+            {"ct", 20},
+            {"cs", 21},
+            {"ws", 22},
+            {"ks", 23},
+            {"ph", 24},
+
+            {"ww", 25},
+            {"ga", 26},
+            {"gr", 27},
+            {"hg", 28},
+
+            {"ds", 29},
+            {"ft", 30},
+            {"bd", 31},
+
+            {"bt", 32},
+            {"hs", 33},
+
+            {"no", 34},
+            {"ec", 35},
+            {"cf", 36},
+            {"bb", 37},
+
+            {"pd", 38},
+            {"cg", 39},
+
+            {"rg", 40},
+            {"gm", 41},
+
+            {"qc", 42},
+            {"qt", 43},
+            {"qg", 44},
+
+            {"pe", 45},
+            {"pa", 46},
+            {"pb", 47},
+
+            {"ut", 48},
+            {"lt", 49}
+        };
     }
 }

--- a/Source/GUIController.cs
+++ b/Source/GUIController.cs
@@ -109,6 +109,7 @@ namespace Benchwarp
         private void DetectHotkeys() {
             if (!(GameManager.instance != null && GameManager.instance.IsGamePaused() && Benchwarp.instance.globalSettings.EnableHotkeys))
             {
+                last2Keystrokes = "";
                 return;
             }
             

--- a/Source/GUIController.cs
+++ b/Source/GUIController.cs
@@ -130,6 +130,10 @@ namespace Benchwarp
                 Bench.Benches[benchNum].SetBench();
                 GameManager.instance.StartCoroutine(Benchwarp.instance.Respawn());
             }
+            else if (last2Keystrokes == "lb")
+            {
+                GameManager.instance.StartCoroutine(Benchwarp.instance.Respawn());
+            }
         }
 
         public static GUIController Instance

--- a/Source/GUIController.cs
+++ b/Source/GUIController.cs
@@ -107,6 +107,11 @@ namespace Benchwarp
         }
 
         private void DetectHotkeys() {
+            if (!GameManager.instance.IsGamePaused())
+            {
+                return;
+            }
+            
             foreach (var letter in BenchLetters)
             {
                 if (Input.GetKeyDown(letter.Key))

--- a/Source/GUIController.cs
+++ b/Source/GUIController.cs
@@ -107,7 +107,7 @@ namespace Benchwarp
         }
 
         private void DetectHotkeys() {
-            if (!GameManager.instance.IsGamePaused())
+            if (!(GameManager.instance.IsGamePaused() && Benchwarp.instance.globalSettings.EnableHotkeys))
             {
                 return;
             }

--- a/Source/GUIController.cs
+++ b/Source/GUIController.cs
@@ -107,40 +107,38 @@ namespace Benchwarp
         }
 
         private void DetectHotkeys() {
-            if (!(GameManager.instance.IsGamePaused() && Benchwarp.instance.globalSettings.EnableHotkeys))
+            if (!(GameManager.instance != null && GameManager.instance.IsGamePaused() && Benchwarp.instance.globalSettings.EnableHotkeys))
             {
                 return;
             }
             
             foreach (var letter in BenchLetters)
             {
-                if (Input.GetKeyDown(letter.Key))
+                if (Input.GetKeyDown(letter))
                 {
                     if (last2Keystrokes.Length == 2)
                     {
                         last2Keystrokes = last2Keystrokes.Remove(0, 1);
                     }
-                    last2Keystrokes = last2Keystrokes + letter.Value;
+                    last2Keystrokes = last2Keystrokes + letter.ToString();
                 }
             }
-            if (BenchHotkeys.TryGetValue(last2Keystrokes, out int benchNum))
+            if (Benchwarp.instance.Hotkeys.TryGetValue(last2Keystrokes, out int benchNum))
             {
                 last2Keystrokes = "";
-                Benchwarp.instance.ApplyUnlockAllFixes();
-                Bench.Benches[benchNum].SetBench();
+                switch (benchNum)
+                {
+                    case -1:
+                        break;
+                    case -2:
+                        CustomStartLocation.SetStart();
+                        break;
+                    default:
+                        Benchwarp.instance.ApplyUnlockAllFixes();
+                        Bench.Benches[benchNum].SetBench();
+                        break;
+                }
                 Benchwarp.instance.Warp();
-            }
-            else switch (last2Keystrokes)
-            {
-                case "lb":
-                    last2Keystrokes = "";
-                    Benchwarp.instance.Warp();
-                    break;
-                case "sb":
-                    last2Keystrokes = "";
-                    CustomStartLocation.SetStart();
-                    Benchwarp.instance.Warp();
-                    break;
             }
         }
 
@@ -164,94 +162,9 @@ namespace Benchwarp
             }
         }
 
-        private static Dictionary<KeyCode, char> BenchLetters = new Dictionary<KeyCode, char>() {
-            {KeyCode.A, 'a'},
-            {KeyCode.B, 'b'},
-            {KeyCode.C, 'c'},
-            {KeyCode.D, 'd'},
-            {KeyCode.E, 'e'},
-            {KeyCode.F, 'f'},
-            {KeyCode.G, 'g'},
-            {KeyCode.H, 'h'},
-            {KeyCode.K, 'k'},
-            {KeyCode.L, 'l'},
-            {KeyCode.M, 'm'},
-            {KeyCode.N, 'n'},
-            {KeyCode.O, 'o'},
-            {KeyCode.P, 'p'},
-            {KeyCode.Q, 'q'},
-            {KeyCode.R, 'r'},
-            {KeyCode.S, 's'},
-            {KeyCode.T, 't'},
-            {KeyCode.U, 'u'},
-            {KeyCode.W, 'w'}
-        };
-
-        private static Dictionary<string, int> BenchHotkeys = new Dictionary<string, int>() {
-            {"kp", 0},
-            {"dm", 1},
-            {"nm", 2},
-
-            {"fs", 3},
-            {"fc", 4},
-            {"sa", 5},
-            {"am", 6},
-            {"be", 7},
-
-            {"gw", 8},
-            {"ss", 9},
-            {"gt", 10},
-            {"gp", 11},
-            {"lu", 12},
-            {"ns", 13},
-
-            {"ta", 14},
-
-            {"qs", 15},
-            {"le", 16},
-            {"br", 17},
-            {"mv", 18},
-
-            {"cq", 19},
-            {"ct", 20},
-            {"cs", 21},
-            {"ws", 22},
-            {"ks", 23},
-            {"ph", 24},
-
-            {"ww", 25},
-            {"ga", 26},
-            {"gr", 27},
-            {"hg", 28},
-
-            {"ds", 29},
-            {"ft", 30},
-            {"bd", 31},
-
-            {"bt", 32},
-            {"hs", 33},
-
-            {"no", 34},
-            {"ec", 35},
-            {"cf", 36},
-            {"bb", 37},
-
-            {"pd", 38},
-            {"cg", 39},
-
-            {"rg", 40},
-            {"gm", 41},
-
-            {"qc", 42},
-            {"qt", 43},
-            {"qg", 44},
-
-            {"pe", 45},
-            {"pa", 46},
-            {"pb", 47},
-
-            {"ut", 48},
-            {"lt", 49}
+        private static HashSet<KeyCode> BenchLetters = new HashSet<KeyCode>()
+        {
+            KeyCode.A, KeyCode.B, KeyCode.C, KeyCode.D, KeyCode.E, KeyCode.F, KeyCode.G, KeyCode.H, KeyCode.I, KeyCode.J, KeyCode.K, KeyCode.L, KeyCode.M, KeyCode.N, KeyCode.O, KeyCode.P, KeyCode.Q, KeyCode.R, KeyCode.S, KeyCode.T, KeyCode.U, KeyCode.V, KeyCode.W, KeyCode.X, KeyCode.Y, KeyCode.Z
         };
     }
 }

--- a/Source/GUIController.cs
+++ b/Source/GUIController.cs
@@ -103,11 +103,14 @@ namespace Benchwarp
         public void Update()
         {
             TopMenu.Update();
+            DetectHotkeys();
+        }
+
+        private void DetectHotkeys() {
             foreach (var letter in BenchLetters)
             {
                 if (Input.GetKeyDown(letter.Key))
                 {
-                    Benchwarp.instance.Log($"pressed {letter.Key} {letter.Value}");
                     if (last2Keystrokes.Length == 2)
                     {
                         last2Keystrokes = last2Keystrokes.Remove(0, 1);
@@ -118,7 +121,9 @@ namespace Benchwarp
             if (BenchHotkeys.TryGetValue(last2Keystrokes, out int benchNum))
             {
                 last2Keystrokes = "";
-                Benchwarp.instance.Log($"hit hotkey {last2Keystrokes} for bench {Bench.Benches[benchNum]}");
+                Benchwarp.instance.ApplyUnlockAllFixes();
+                Bench.Benches[benchNum].SetBench();
+                GameManager.instance.StartCoroutine(Benchwarp.instance.Respawn());
             }
         }
 

--- a/Source/Settings.cs
+++ b/Source/Settings.cs
@@ -33,5 +33,6 @@ namespace Benchwarp
         public bool NoPreload = false;
         public bool ReducePreload = true;
         public bool EnableHotkeys = false;
+        public Dictionary<string, string> HotkeyOverrides = new Dictionary<string, string>();
     }
 }

--- a/Source/Settings.cs
+++ b/Source/Settings.cs
@@ -32,5 +32,6 @@ namespace Benchwarp
         public bool NoDarkOrDreamRooms = true;
         public bool NoPreload = false;
         public bool ReducePreload = true;
+        public bool EnableHotkeys = false;
     }
 }

--- a/Source/TopMenu.cs
+++ b/Source/TopMenu.cs
@@ -476,49 +476,7 @@ namespace Benchwarp
                 Benchwarp.instance.SaveGlobalSettings();
             }
 
-            if (!Benchwarp.instance.globalSettings.UnlockAllBenches) return;
-
-            PlayerData pd = PlayerData.instance;
-
-            FieldInfo[] fields = typeof(PlayerData).GetFields();
-
-            // Most of these are unnecessary, but some titlecards can lock you into a bench
-            foreach
-            (
-                FieldInfo fi in fields.Where
-                (
-                    x => x.Name.StartsWith("visited")
-                        || x.Name.StartsWith("tramOpened")
-                        || x.Name.StartsWith("openedTram")
-                        || x.Name.StartsWith("tramOpened")
-                )
-            )
-            {
-                pd.SetBoolInternal(fi.Name, true);
-            }
-
-            //This actually fixes the unlockable benches
-            SceneData sd = GameManager.instance.sceneData;
-
-            foreach ((string sceneName, string id) in new (string, string)[]
-            {
-                ("Hive_01", "Hive Bench"),
-                ("Ruins1_31", "Toll Machine Bench"),
-                ("Abyss_18", "Toll Machine Bench"),
-                ("Fungus3_50", "Toll Machine Bench")
-            })
-            {
-                sd.SaveMyState
-                (
-                    new PersistentBoolData
-                    {
-                        sceneName = sceneName,
-                        id = id,
-                        activated = true,
-                        semiPersistent = false
-                    }
-                );
-            }
+            Benchwarp.instance.ApplyUnlockAllFixes();
         }
 
         private static void ShowSceneClicked(string buttonName)

--- a/Source/TopMenu.cs
+++ b/Source/TopMenu.cs
@@ -39,7 +39,8 @@ namespace Benchwarp
                     ("Show Room Name", ShowSceneClicked, t.GetField(nameof(GlobalSettings.ShowScene))),
                     ("Use Room Names", SwapNamesClicked, t.GetField(nameof(GlobalSettings.SwapNames))),
                     ("Enable Deploy", EnableDeployClicked, t.GetField(nameof(GlobalSettings.EnableDeploy))),
-                    ("Always Toggle All", AlwaysToggleAllClicked, t.GetField(nameof(GlobalSettings.AlwaysToggleAll)))
+                    ("Always Toggle All", AlwaysToggleAllClicked, t.GetField(nameof(GlobalSettings.AlwaysToggleAll))),
+                    ("Enable Hotkeys", EnableHotkeysClicked, t.GetField(nameof(GlobalSettings.EnableHotkeys))),
                 }
             };
 
@@ -52,7 +53,7 @@ namespace Benchwarp
 
         private static readonly Dictionary<string, (UnityAction<string>, Vector2)> CustomStartButtons = new Dictionary<string, (UnityAction<string>, Vector2)>
         {
-            ["Set Start"] = (s => CustomStartLocation.SetStart(), new Vector2(1446f, 300f))
+            ["Set Start"] = (s => CustomStartLocation.SetStart(), new Vector2(1446f, 340f))
         };
 
         public static void BuildMenu(GameObject _canvas)
@@ -507,6 +508,12 @@ namespace Benchwarp
         private static void AlwaysToggleAllClicked(string buttonName)
         {
             Benchwarp.instance.globalSettings.AlwaysToggleAll = !Benchwarp.instance.globalSettings.AlwaysToggleAll;
+            Benchwarp.instance.SaveGlobalSettings();
+        }
+
+        private static void EnableHotkeysClicked(string buttonName)
+        {
+            Benchwarp.instance.globalSettings.EnableHotkeys = !Benchwarp.instance.globalSettings.EnableHotkeys;
             Benchwarp.instance.SaveGlobalSettings();
         }
 

--- a/Source/TopMenu.cs
+++ b/Source/TopMenu.cs
@@ -374,7 +374,7 @@ namespace Benchwarp
             if (Benchwarp.instance.globalSettings.UnlockAllBenches)
                 UnlockAllClicked(null);
 
-            GameManager.instance.StartCoroutine(Benchwarp.instance.Respawn());
+            Benchwarp.instance.Warp();
         }
 
         private static void DeployClicked(string buttonName)


### PR DESCRIPTION
See the README for a list of hotkeys and details on how to configure them.

To avoid accidental warps, hotkeys only trigger while the game is paused.