### PR TITLE
Add some global settings to the menu

### DIFF
--- a/Benchwarp/Settings.cs
+++ b/Benchwarp/Settings.cs
@@ -18,11 +18,17 @@ namespace Benchwarp
     [Serializable]
     public class GlobalSettings
     {
+        [MenuToggleable(name: "Show Menu", description: "Toggle only the Benchwarp Menu UI")]
+        public bool ShowMenu = true;
+        [MenuToggleable(name: "Warp Only")]
         public bool WarpOnly = false;
+        [MenuToggleable(name: "Unlock All")]
         public bool UnlockAllBenches = false;
         public bool ShowScene = false;
         public bool SwapNames = false;
+        [MenuToggleable(name: "Enable Deploy")]
         public bool EnableDeploy = true;
+        [MenuToggleable(name: "Always Toggle All")]
         public bool AlwaysToggleAll = false;
         public bool ModifyVanillaBenchStyles = false;
         public string nearStyle = "Right";
@@ -32,9 +38,22 @@ namespace Benchwarp
         public bool NoMidAirDeploy = true;
         public bool NoDarkOrDreamRooms = true;
         public bool NoPreload = false;
+        [MenuToggleable(name: "Door Warp")]
         public bool DoorWarp = false;
+        [MenuToggleable(name: "Enable Hotkeys")]
         public bool EnableHotkeys = false;
-        public bool ShowMenu = true;
         public Dictionary<string, string> HotkeyOverrides = new Dictionary<string, string>();
+    }
+
+    public class MenuToggleableAttribute : Attribute
+    {
+        public string name;
+        public string description;
+
+        public MenuToggleableAttribute(string name, string description = "")
+        {
+            this.name = name;
+            this.description = description;
+        }
     }
 }


### PR DESCRIPTION
This allows the user to modify the global settings from the main menu. Example use case - switching to warp-only for speedrunning. I think the most important option is warp only, but I added a few more. I didn't bother adding descriptions but they could maybe be added, I guess?