### PR TITLE
Make warping trigger TimePasses

### DIFF
--- a/Benchwarp/ChangeScene.cs
+++ b/Benchwarp/ChangeScene.cs
@@ -23,6 +23,7 @@ namespace Benchwarp
         private static IEnumerator Respawn()
         {
             GameManager.instance.SaveGame();
+            GameManager.instance.TimePasses();
             GameManager.instance.ResetSemiPersistentItems();
             UIManager.instance.UIClosePauseMenu();
 


### PR DESCRIPTION
I'm not sure if this really needs to change, but it means that Millibelle is correctly banished to Pleasure House when warping (as if the player had done a SaveQuit) as well as some other irrelevant changes.