### PR TITLE
Allow the player to have control if they warp to a non-bench while di…

### DIFF
--- a/Benchwarp/ChangeScene.cs
+++ b/Benchwarp/ChangeScene.cs
@@ -56,6 +56,12 @@ namespace Benchwarp
 
             // Actually respawn the character
             GameManager.instance.SetPlayerDataBool(nameof(PlayerData.atBench), false);
+            // Allow the player to have control if they warp to a non-bench while diving or cdashing
+            if (HeroController.instance != null)
+            {
+                HeroController.instance.cState.superDashing = false;
+                HeroController.instance.cState.spellQuake = false;
+            }
             GameManager.instance.ReadyForRespawn(false);
 
             yield return new WaitWhile(() => GameManager.instance.IsInSceneTransition);


### PR DESCRIPTION
…ving or cdashing

This includes hard saves (e.g. dirtmouth) and set start. Normally, it's fine if the player doesn't have control because they don't have control on a bench anyway. For a hard save they should have control; GM.BeginSceneTransitionRoutine sets the enterQuake/resp. bool to true, and HC.FinishedEnteringScene takes away control because it thinks they're diving. Normally when going through an invalid transition (e.g. doorwarp to a left transition while diving) HC.EnterScene unsets the exitedQuake bool, so control isn't taken away.