### PR TITLE
Show all loaded scene names in bottom left when showing scene names

### DIFF
--- a/Benchwarp/Benchwarp.cs
+++ b/Benchwarp/Benchwarp.cs
@@ -218,9 +218,20 @@ namespace Benchwarp
 
             foreach (FieldInfo fi in typeof(GlobalSettings).GetFields())
             {
-                if (fi.FieldType != typeof(bool))
+                if (fi.GetCustomAttribute<MenuIntAttribute>() is MenuIntAttribute mi)
                 {
-                    continue;
+                    menuEntries.Add(new()
+                    {
+                        Name = mi.name,
+                        Description = mi.description,
+                        Values = mi.values,
+                        Saver = opt => fi.SetValue(GS, int.Parse(mi.values[opt])),
+                        Loader = () =>
+                        {
+                            string needle = ((int) fi.GetValue(GS)).ToString();
+                            return Array.FindIndex(mi.values, s => s == needle);
+                        }
+                    });
                 }
                 if (fi.GetCustomAttribute<MenuToggleableAttribute>() is MenuToggleableAttribute mt)
                 {

--- a/Benchwarp/Benchwarp.csproj
+++ b/Benchwarp/Benchwarp.csproj
@@ -6,9 +6,9 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <RootNamespace>Benchwarp</RootNamespace>
     <AssemblyName>Benchwarp</AssemblyName>
-    <AssemblyVersion>3.1.2</AssemblyVersion>
+    <AssemblyVersion>3.1.3</AssemblyVersion>
     <LangVersion>latest</LangVersion>
-    <FileVersion>3.1.2</FileVersion>
+    <FileVersion>3.1.3</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Assembly-CSharp">

--- a/Benchwarp/Settings.cs
+++ b/Benchwarp/Settings.cs
@@ -25,6 +25,8 @@ namespace Benchwarp
         [MenuToggleable(name: "Unlock All")]
         public bool UnlockAllBenches = false;
         public bool ShowScene = false;
+        [MenuInt("Max Displayed Room Names", 1, 20, 1)]
+        public int MaxSceneNames = 1;
         public bool SwapNames = false;
         [MenuToggleable(name: "Enable Deploy")]
         public bool EnableDeploy = true;
@@ -54,6 +56,20 @@ namespace Benchwarp
         {
             this.name = name;
             this.description = description;
+        }
+    }
+
+    public class MenuIntAttribute : Attribute
+    {
+        public string name;
+        public string description;
+        public string[] values;
+
+        public MenuIntAttribute(string name, int min, int max, int step, string description = "")
+        {
+            this.name = name;
+            this.description = description;
+            this.values = Enumerable.Range(0, (max - min + 1) / step).Select(x => (x * step + min).ToString()).ToArray();
         }
     }
 }

--- a/Benchwarp/TopMenu.cs
+++ b/Benchwarp/TopMenu.cs
@@ -6,6 +6,8 @@ using UnityEngine;
 using UnityEngine.Events;
 using Benchwarp.CanvasUtil;
 
+using USceneManager = UnityEngine.SceneManagement.SceneManager;
+
 namespace Benchwarp
 {
     public static class DoorWarpSelection
@@ -420,7 +422,29 @@ namespace Benchwarp
                     Vector2 heroPos = HeroController.instance.transform.position;
                     sceneText += $" {heroPos}";
                 }
-                sceneNamePanel.GetText("SceneName").UpdateText(sceneText);
+
+                var sceneNameText = sceneNamePanel.GetText("SceneName");
+                
+                if (gs.MaxSceneNames > 1)
+                {
+                    int nLines = 1;
+                
+                    for (int i = 1; i < Math.Min(USceneManager.sceneCount, gs.MaxSceneNames); i++)
+                    {
+                        sceneText += $"\n{Events.GetSceneName(USceneManager.GetSceneAt(i).name)}";
+                        nLines++;
+                    }
+
+                    if (USceneManager.sceneCount > gs.MaxSceneNames)
+                    {
+                        sceneText += $"\n(+ {USceneManager.sceneCount - gs.MaxSceneNames} more)";
+                        nLines++;
+                    }
+                    
+                    sceneNameText.SetPosition(new Vector2(5f, 1080f - 20 * nLines));
+                }
+
+                sceneNameText.UpdateText(sceneText);
             }
             else sceneNamePanel.SetActive(false, true);
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Options
 - Warp Only: removes bench selection menu
 - Unlock All: enables all benches on the selection menu
 - Show Room Name: displays the name of the current room from the game code in the bottom left
+- Max Displayed Room Names: if `Show Room Name` is enabled, show up to this many additional loaded rooms
 - Use Room Names: bench menu uses room names from the game code instead of descriptive names
 - Enable Deploy: adds a menu to place a custom bench point
 - Always Toggle All: all bench menus are displayed by default


### PR DESCRIPTION
Add new option "Max Displayed Room Names", changeable in mod settings, that allows multiple loaded room names to be shown with "Show Room Names", mostly for CP room dupes. Default value of 1 leaves behavior as is.