### PR TITLE
Add localization override as mods menu option

### DIFF
--- a/Benchwarp/GlobalSettings.cs
+++ b/Benchwarp/GlobalSettings.cs
@@ -30,6 +30,8 @@
         public bool EnableHotkeys = false;
         [MenuToggleable(name: "Legacy Hotkeys", description: "Toggle Benchwarp or restart to apply changes")]
         public bool LegacyHotkeys = false;
+        [MenuToggleable(name: "Override Localization", description: "Keeps Benchwarp in English regardless of game language")]
+        public bool OverrideLocalization = false;
 
         public Dictionary<string, string> HotkeyOverrides = new();
     }

--- a/Benchwarp/Localization.cs
+++ b/Benchwarp/Localization.cs
@@ -54,6 +54,8 @@ public static class Localization
 
     public static string Localize(string text) 
     {
+        if (Benchwarp.GS.OverrideLocalization) return text;
+
         return _map is not null && _map.TryGetValue(text, out string newText) ? newText : text;
     }
 }

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Options
 	- While active, the Warp button can only be used to warp to the selected transition, and will not warp to respawn.
 	- The Flip button is used to change selection to the (vanilla) target of the currently selected transition.
 - Enable Hotkeys: lets you warp to benches by typing a short key sequence rather than clicking the menu
+- Override Localization: leaves bench names & UI in English when the game is in Chinese
 
 Deploy
 - Deploy button: places a bench at the current location


### PR DESCRIPTION
Added a basic toggle override to allow benchwarp to be used in English while using Chinese as the game language (eg. debug install).

Closes #33 